### PR TITLE
fix: Fix name convertor

### DIFF
--- a/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/util/StringExtensions.kt
+++ b/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/util/StringExtensions.kt
@@ -3,17 +3,49 @@ package dev.hsbrysk.protoc.gen.util
 /**
  * Convert kebab case or snake case to Pascal case (a.k.a. upper camel case).
  */
-internal fun String.pascalCase(): String = hyphenToUnderscore().split("_").joinToString("") { value ->
-    value.replaceFirstChar { it.uppercase() }
+internal fun String.pascalCase(): String = buildString {
+    var capitalizeNext = true
+    for (c in hyphenToUnderscore()) {
+        when {
+            c == '_' -> {
+                capitalizeNext = true
+            }
+            c.isDigit() -> {
+                append(c)
+                capitalizeNext = true
+            }
+            else -> {
+                append(if (capitalizeNext) c.uppercase() else c)
+                capitalizeNext = false
+            }
+        }
+    }
 }
 
 /**
  * Convert kebab case or snake case to camel case.
  */
-internal fun String.camelCase(): String =
-    hyphenToUnderscore().split("_").withIndex().joinToString("") { (index, value) ->
-        if (index == 0) value.replaceFirstChar { it.lowercase() } else value.replaceFirstChar { it.uppercase() }
+internal fun String.camelCase(): String = buildString {
+    var capitalizeNext = false
+    for ((i, c) in hyphenToUnderscore().withIndex()) {
+        when {
+            c == '_' -> {
+                capitalizeNext = true
+            }
+            i == 0 -> {
+                append(c.lowercase())
+            }
+            c.isDigit() -> {
+                append(c)
+                capitalizeNext = true
+            }
+            else -> {
+                append(if (capitalizeNext) c.uppercase() else c)
+                capitalizeNext = false
+            }
+        }
     }
+}
 
 // We want to support both `-` and `_`, so...
 private fun String.hyphenToUnderscore() = replace("-", "_")

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/StringExtensionsTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/StringExtensionsTest.kt
@@ -13,6 +13,7 @@ class StringExtensionsTest {
         assertThat("Hoge-Bar".pascalCase()).isEqualTo("HogeBar")
         assertThat("Hoge_Bar".pascalCase()).isEqualTo("HogeBar")
         assertThat("あ-_い".pascalCase()).isEqualTo("あい")
+        assertThat("k8s_cluster".pascalCase()).isEqualTo("K8SCluster")
     }
 
     @Test
@@ -23,5 +24,6 @@ class StringExtensionsTest {
         assertThat("Hoge-Bar".camelCase()).isEqualTo("hogeBar")
         assertThat("Hoge_Bar".camelCase()).isEqualTo("hogeBar")
         assertThat("あ-_い".camelCase()).isEqualTo("あい")
+        assertThat("K8s_cluster".camelCase()).isEqualTo("k8SCluster")
     }
 }


### PR DESCRIPTION
- Hi, thank you for this project

## Description
- The gRPC Java codegen makes `k8s_cluster` field name to `K8SCluster`.
- But because of the `protoc-gen-kotlin-ext` makes `k8s_cluster` to `K8sCluster`, the compilation error is occuring.
- Fix it to works