### PR TITLE
Add support for Protocol Buffers editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 A protoc compiler plugin that generates useful extension code for Kotlin.
 
+## Supported syntax
+
+| Syntax | Supported |
+|--------|-----------|
+| proto3 | ✓ |
+| editions (edition 2023 and later) | ✓ |
+| proto2 | - |
+
+Requires `protobuf-java` 4.x or later.
+
 ## Features
 
 - Generate `*OrNull` extension properties for optional field

--- a/functional-test/build.gradle.kts
+++ b/functional-test/build.gradle.kts
@@ -11,6 +11,11 @@ description = "Function test module for protoc-gen-kotlin-ext"
 
 val withProtocGenKotlin = providers.gradleProperty("withProtocGenKotlin").isPresent
 
+// Separate source set for editions .proto files since protoc-gen-grpckt does not yet support editions.
+sourceSets {
+    create("editions")
+}
+
 dependencies {
     implementation(libs.protobuf.java)
     if (withProtocGenKotlin) {
@@ -18,6 +23,13 @@ dependencies {
     }
     implementation(libs.grpc.java.protobuf)
     implementation(libs.grpc.kotlin.stub)
+
+    "editionsImplementation"(libs.protobuf.java)
+    if (withProtocGenKotlin) {
+        "editionsImplementation"(libs.protobuf.kotlin)
+    }
+    // Make generated editions code visible to main and test source sets.
+    implementation(sourceSets["editions"].output)
 }
 
 protobuf {
@@ -40,6 +52,8 @@ protobuf {
         all().forEach { task ->
             task.dependsOn(":protoc-gen-kotlin-ext:installDist")
 
+            val isEditions = task.sourceSet.name == "editions"
+
             if (withProtocGenKotlin) {
                 task.builtins {
                     id("kotlin")
@@ -52,13 +66,15 @@ protobuf {
                         option("messageOrNullGetter+")
                     }
                 }
-                // Test to ensure there are no issues when using gen-grpc-java.
-                id("grpc") {
-                    outputSubDir = "java"
-                }
-                // Test to ensure there are no issues when using gen-grpc-kotlin.
-                id("grpckt") {
-                    outputSubDir = "kotlin"
+                if (!isEditions) {
+                    // Test to ensure there are no issues when using gen-grpc-java.
+                    id("grpc") {
+                        outputSubDir = "java"
+                    }
+                    // Test to ensure there are no issues when using gen-grpc-kotlin.
+                    id("grpckt") {
+                        outputSubDir = "kotlin"
+                    }
                 }
             }
         }

--- a/functional-test/src/editions/proto/example/editions.proto
+++ b/functional-test/src/editions/proto/example/editions.proto
@@ -1,0 +1,47 @@
+edition = "2023";
+
+package example;
+
+option java_package = "example.protocol";
+option java_multiple_files = true;
+option features.field_presence = IMPLICIT;
+
+message EditionsMessage {
+  // IMPLICIT presence (file-level default) - no OrNull generated
+  int32 implicit_int32 = 1;
+  string implicit_string = 2;
+
+  // EXPLICIT presence - OrNull generated
+  int32 explicit_int32 = 3 [features.field_presence = EXPLICIT];
+  string explicit_string = 4 [features.field_presence = EXPLICIT];
+
+  // Message field (always EXPLICIT in editions 2023) - OrNull generated
+  EditionsNested nested = 5;
+
+  // repeated field - no OrNull
+  repeated string repeated_string = 6;
+
+  // map field - no OrNull
+  map<string, string> map_field = 7;
+
+  // oneof fields - each field has OrNull
+  oneof test_one_of {
+    string one_of_a = 8;
+    string one_of_b = 9;
+  }
+
+  // enum field - IMPLICIT (no OrNull)
+  EditionsEnum enum_fd = 10;
+
+  // enum field - EXPLICIT (OrNull generated)
+  EditionsEnum explicit_enum = 11 [features.field_presence = EXPLICIT];
+}
+
+message EditionsNested {
+  string value = 1;
+}
+
+enum EditionsEnum {
+  EDITIONS_ENUM_UNSPECIFIED = 0;
+  EDITIONS_ENUM_A = 1;
+}

--- a/functional-test/src/test/kotlin/example/protocol/EditionsTest.kt
+++ b/functional-test/src/test/kotlin/example/protocol/EditionsTest.kt
@@ -1,0 +1,50 @@
+package example.protocol
+
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import org.junit.jupiter.api.Test
+
+@Suppress("RedundantExplicitType")
+class EditionsTest {
+    @Test
+    fun compileCheck() {
+        val message: EditionsMessage = EditionsMessage(
+            implicitInt32 = 0,
+            implicitString = "",
+            explicitInt32 = null,
+            explicitString = null,
+            nested = null,
+            repeatedStringList = listOf(),
+            mapFieldMap = mapOf(),
+            oneOfA = null,
+            oneOfB = null,
+            enumFd = EditionsEnum.EDITIONS_ENUM_UNSPECIFIED,
+            explicitEnum = null,
+        )
+
+        assertThat(message.explicitInt32OrNull).isNull()
+        assertThat(message.explicitStringOrNull).isNull()
+        assertThat(message.nestedOrNull).isNull()
+        assertThat(message.explicitEnumOrNull).isNull()
+
+        val messageWithValues: EditionsMessage = EditionsMessage(
+            implicitInt32 = 42,
+            implicitString = "hello",
+            explicitInt32 = 100,
+            explicitString = "world",
+            nested = EditionsNested(value = "nested_value"),
+            repeatedStringList = listOf("a", "b"),
+            mapFieldMap = mapOf("key" to "value"),
+            oneOfA = "one_of_a",
+            oneOfB = null,
+            enumFd = EditionsEnum.EDITIONS_ENUM_A,
+            explicitEnum = EditionsEnum.EDITIONS_ENUM_A,
+        )
+
+        assertThat(messageWithValues.explicitInt32OrNull).isNotNull()
+        assertThat(messageWithValues.explicitStringOrNull).isNotNull()
+        assertThat(messageWithValues.nestedOrNull).isNotNull()
+        assertThat(messageWithValues.explicitEnumOrNull).isNotNull()
+    }
+}

--- a/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunner.kt
+++ b/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunner.kt
@@ -1,5 +1,6 @@
 package dev.hsbrysk.protoc.gen
 
+import com.google.protobuf.DescriptorProtos.Edition
 import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
@@ -18,7 +19,12 @@ object GeneratorRunner {
         val fileSpecs = generateFileSpecs(generatorRequest)
 
         val generatorResponse = CodeGeneratorResponse.newBuilder()
-            .setSupportedFeatures(Feature.FEATURE_PROTO3_OPTIONAL_VALUE.toLong())
+            .setSupportedFeatures(
+                Feature.FEATURE_PROTO3_OPTIONAL_VALUE.toLong() or
+                    Feature.FEATURE_SUPPORTS_EDITIONS_VALUE.toLong(),
+            )
+            .setMinimumEdition(Edition.EDITION_PROTO2_VALUE)
+            .setMaximumEdition(Edition.EDITION_2024_VALUE)
             .addAllFile(
                 fileSpecs.map {
                     CodeGeneratorResponse.File.newBuilder()
@@ -51,7 +57,7 @@ object GeneratorRunner {
 
         return request.fileToGenerateList
             .map { fileDescriptorMap.getValue(it) }
-            .filter { it.toProto().syntax == "proto3" } // Only target proto3.
+            .filter { it.toProto().syntax in setOf("proto3", "editions") } // Only target proto3 and editions.
             .map { fileDescriptor ->
                 val fileSpecBuilder = FileSpec.builder(
                     fileDescriptor.javaPackage,


### PR DESCRIPTION
  ## Summary

  - Declare `FEATURE_SUPPORTS_EDITIONS` in `CodeGeneratorResponse.supported_features` so protoc recognises this plugin as editions-capable
  - Set `minimum_edition = EDITION_PROTO2` and `maximum_edition = EDITION_2024` to define the supported edition range
  - Expand the file filter in `GeneratorRunner` from `syntax == "proto3"` to `syntax in {"proto3", "editions"}`, enabling code generation for editions `.proto` files
  - Add a functional test (`editions.proto` + `EditionsTest`) that verifies `*OrNull` properties and factory functions are generated correctly under editions 2023, covering `IMPLICIT` and `EXPLICIT` field presence, message fields,
  repeated, map, oneof, and enum fields
  - Isolate editions `.proto` files in a dedicated Gradle source set (`editions`) to work around `protoc-gen-grpckt` not yet supporting editions
  - Document supported syntaxes (proto3, editions 2023+; proto2 not supported) in README

  ## Background

  Previously the plugin silently skipped any `.proto` file that was not `syntax = "proto3"`. With the protobuf ecosystem moving toward editions as the canonical way to write `.proto` files, this change makes `protoc-gen-kotlin-ext`          compatible with editions files while keeping full backward compatibility for existing proto3 users.

  No changes were needed in the core generation logic (`FactoryGenerator`, `AbstractOrNullGetterGenerator`, `DescriptorExtensions`) because they already rely on the Descriptors API abstractions (`hasPresence()`, `isMapField`, `isRepeated`)
   which are editions-aware in `protobuf-java` 4.x.
                                                                                                                                                                                              ## Test plan

  - [x] `./gradlew :protoc-gen-kotlin-ext:test` — unit tests pass
  - [x] `./gradlew :functional-test:clean :functional-test:test` — functional tests pass (standalone mode)
  - [x] `./gradlew :functional-test:clean :functional-test:test -PwithProtocGenKotlin` — functional tests pass (with official protoc-gen-kotlin)
  - [x] `./gradlew check` — all checks (tests, ktlint, detekt) pass