### PR TITLE
docs: add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+protoc コンパイラプラグイン。Kotlin 向けの拡張コード(optional フィールド用の `*OrNull` 拡張プロパティ、data class 風のファクトリ関数)を生成する。独自のメッセージクラスは生成せず、公式の protobuf-java が生成するクラスに対する追加コードのみを生成する。proto3 のみ対象。
+
+## よく使うコマンド
+
+```bash
+# ビルド + 全テスト + lint(ktlint / detekt)
+./gradlew check
+
+# プラグイン本体のユニットテストのみ
+./gradlew :protoc-gen-kotlin-ext:test
+
+# 単一テストクラスの実行
+./gradlew :protoc-gen-kotlin-ext:test --tests "dev.hsbrysk.protoc.gen.CompileOptionTest"
+
+# functional-test(実際に protoc でコード生成して検証)
+./gradlew :functional-test:test
+
+# protobuf-kotlin 併用モードでの functional-test(CI でも実行される)
+./gradlew :functional-test:clean :functional-test:test -PwithProtocGenKotlin
+
+# lint 修正
+./gradlew ktlintFormat
+```
+
+- Kotlin 本体は Java 8 toolchain でコンパイルされる(foojay-resolver が JDK を自動ダウンロード)。`allWarningsAsErrors = true` なので警告もビルドエラーになる。
+- テストは JUnit 5 + assertk。
+
+## アーキテクチャ
+
+### モジュール構成
+
+- `protoc-gen-kotlin-ext/` — プラグイン本体。`GeneratorRunner.main` を Main-Class とする fat jar として配布される。
+- `functional-test/` — `src/main/proto/` の proto を、ローカルビルドしたプラグイン(`:protoc-gen-kotlin-ext:installDist` の成果物)で実際にコード生成し、生成コードの挙動をテストするモジュール。grpc-java / grpc-kotlin プラグインとの共存も検証している。
+- `build-logic/` — convention plugin(`conventions.kotlin` / `conventions.ktlint` / `conventions.detekt`)。included build。
+
+### プラグインの処理フロー(protoc-gen-kotlin-ext)
+
+protoc プラグインプロトコルに従い、stdin から `CodeGeneratorRequest` を読み、stdout に `CodeGeneratorResponse` を書く。エントリポイントは `GeneratorRunner`:
+
+1. `CompileOption.parseOptions` がコンパイルオプション(`factory` / `orNullGetter` / `messageOrNullGetter`、`+`/`-` サフィックスで on/off)をパースし、有効な `Generator` のリストを決める。
+2. proto ファイルごとに KotlinPoet の `FileSpec.Builder` を作り(出力ファイル名は `<Protoファイル名のPascalCase>KtExtensions.kt`)、各 `Generator.apply` が拡張コードを追加していく。
+
+`Generator` の実装は 3 つ:
+
+- `FactoryGenerator` — data class コンストラクタ風のファクトリ関数を生成(デフォルト on)
+- `OrNullGetterGenerator` — optional スカラーフィールド向け `*OrNull` 拡張プロパティ(デフォルト on)
+- `MessageOrNullGetterGenerator` — メッセージ型フィールド向け `*OrNull`(デフォルト off。protobuf-kotlin 使用時は protoc-gen-kotlin 側が同等のものを生成するため)
+
+後者 2 つは `AbstractOrNullGetterGenerator` を共有する。`util/` 配下に Descriptor から Java パッケージ名・クラス名・ネスト構造を解決する拡張関数群があり、outer class 名の衝突や Kotlin キーワードのエスケープなどのエッジケースはここで処理される(functional-test の `outer_class_same_*.proto` や `keyword.proto` が対応するテスト)。
+
+### リリース
+
+`v X.Y.Z` 形式のタグ push で `.github/workflows/publish.yml` が `sonatypeCentralUpload` を実行し Maven Central に公開される。バージョンは `-PpublishVersion` / `PUBLISH_VERSION` 環境変数で注入され、未指定時は `latest-SNAPSHOT`。jar は `-jdk8` classifier 付きにリネームして公開される。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,58 +2,58 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## プロジェクト概要
+## Project Overview
 
-protoc コンパイラプラグイン。Kotlin 向けの拡張コード(optional フィールド用の `*OrNull` 拡張プロパティ、data class 風のファクトリ関数)を生成する。独自のメッセージクラスは生成せず、公式の protobuf-java が生成するクラスに対する追加コードのみを生成する。proto3 のみ対象。
+A protoc compiler plugin that generates useful extension code for Kotlin: `*OrNull` extension properties for optional fields and data-class-like factory functions. It does not generate its own message classes — it only generates additional code on top of the classes produced by the official protobuf-java. Only proto3 is targeted.
 
-## よく使うコマンド
+## Common Commands
 
 ```bash
-# ビルド + 全テスト + lint(ktlint / detekt)
+# Build + all tests + lint (ktlint / detekt)
 ./gradlew check
 
-# プラグイン本体のユニットテストのみ
+# Unit tests for the plugin itself
 ./gradlew :protoc-gen-kotlin-ext:test
 
-# 単一テストクラスの実行
+# Run a single test class
 ./gradlew :protoc-gen-kotlin-ext:test --tests "dev.hsbrysk.protoc.gen.CompileOptionTest"
 
-# functional-test(実際に protoc でコード生成して検証)
+# Functional tests (actually run protoc code generation and verify)
 ./gradlew :functional-test:test
 
-# protobuf-kotlin 併用モードでの functional-test(CI でも実行される)
+# Functional tests with protobuf-kotlin enabled (also run in CI)
 ./gradlew :functional-test:clean :functional-test:test -PwithProtocGenKotlin
 
-# lint 修正
+# Fix lint issues
 ./gradlew ktlintFormat
 ```
 
-- Kotlin 本体は Java 8 toolchain でコンパイルされる(foojay-resolver が JDK を自動ダウンロード)。`allWarningsAsErrors = true` なので警告もビルドエラーになる。
-- テストは JUnit 5 + assertk。
+- The Kotlin code is compiled with a Java 8 toolchain (foojay-resolver auto-downloads the JDK). `allWarningsAsErrors = true`, so warnings fail the build.
+- Tests use JUnit 5 + assertk.
 
-## アーキテクチャ
+## Architecture
 
-### モジュール構成
+### Module Layout
 
-- `protoc-gen-kotlin-ext/` — プラグイン本体。`GeneratorRunner.main` を Main-Class とする fat jar として配布される。
-- `functional-test/` — `src/main/proto/` の proto を、ローカルビルドしたプラグイン(`:protoc-gen-kotlin-ext:installDist` の成果物)で実際にコード生成し、生成コードの挙動をテストするモジュール。grpc-java / grpc-kotlin プラグインとの共存も検証している。
-- `build-logic/` — convention plugin(`conventions.kotlin` / `conventions.ktlint` / `conventions.detekt`)。included build。
+- `protoc-gen-kotlin-ext/` — The plugin itself. Distributed as a fat jar with `GeneratorRunner.main` as the Main-Class.
+- `functional-test/` — Runs actual code generation on the protos in `src/main/proto/` using the locally built plugin (the output of `:protoc-gen-kotlin-ext:installDist`) and tests the behavior of the generated code. Also verifies coexistence with the grpc-java / grpc-kotlin plugins.
+- `build-logic/` — Convention plugins (`conventions.kotlin` / `conventions.ktlint` / `conventions.detekt`). Included build.
 
-### プラグインの処理フロー(protoc-gen-kotlin-ext)
+### Plugin Processing Flow (protoc-gen-kotlin-ext)
 
-protoc プラグインプロトコルに従い、stdin から `CodeGeneratorRequest` を読み、stdout に `CodeGeneratorResponse` を書く。エントリポイントは `GeneratorRunner`:
+Following the protoc plugin protocol, it reads a `CodeGeneratorRequest` from stdin and writes a `CodeGeneratorResponse` to stdout. The entry point is `GeneratorRunner`:
 
-1. `CompileOption.parseOptions` がコンパイルオプション(`factory` / `orNullGetter` / `messageOrNullGetter`、`+`/`-` サフィックスで on/off)をパースし、有効な `Generator` のリストを決める。
-2. proto ファイルごとに KotlinPoet の `FileSpec.Builder` を作り(出力ファイル名は `<Protoファイル名のPascalCase>KtExtensions.kt`)、各 `Generator.apply` が拡張コードを追加していく。
+1. `CompileOption.parseOptions` parses the compile options (`factory` / `orNullGetter` / `messageOrNullGetter`, toggled on/off with a `+`/`-` suffix) and determines the list of enabled `Generator`s.
+2. For each proto file, a KotlinPoet `FileSpec.Builder` is created (the output file name is `<PascalCaseProtoFileName>KtExtensions.kt`), and each `Generator.apply` adds extension code to it.
 
-`Generator` の実装は 3 つ:
+There are three `Generator` implementations:
 
-- `FactoryGenerator` — data class コンストラクタ風のファクトリ関数を生成(デフォルト on)
-- `OrNullGetterGenerator` — optional スカラーフィールド向け `*OrNull` 拡張プロパティ(デフォルト on)
-- `MessageOrNullGetterGenerator` — メッセージ型フィールド向け `*OrNull`(デフォルト off。protobuf-kotlin 使用時は protoc-gen-kotlin 側が同等のものを生成するため)
+- `FactoryGenerator` — Generates data-class-constructor-like factory functions (default: on)
+- `OrNullGetterGenerator` — Generates `*OrNull` extension properties for optional scalar fields (default: on)
+- `MessageOrNullGetterGenerator` — Generates `*OrNull` for message-type fields (default: off, because protoc-gen-kotlin already generates the equivalent when protobuf-kotlin is used)
 
-後者 2 つは `AbstractOrNullGetterGenerator` を共有する。`util/` 配下に Descriptor から Java パッケージ名・クラス名・ネスト構造を解決する拡張関数群があり、outer class 名の衝突や Kotlin キーワードのエスケープなどのエッジケースはここで処理される(functional-test の `outer_class_same_*.proto` や `keyword.proto` が対応するテスト)。
+The latter two share `AbstractOrNullGetterGenerator`. The extension functions under `util/` resolve Java package names, class names, and nesting structure from descriptors; edge cases such as outer class name collisions and Kotlin keyword escaping are handled there (the corresponding tests are `outer_class_same_*.proto` and `keyword.proto` in functional-test).
 
-### リリース
+### Release
 
-`v X.Y.Z` 形式のタグ push で `.github/workflows/publish.yml` が `sonatypeCentralUpload` を実行し Maven Central に公開される。バージョンは `-PpublishVersion` / `PUBLISH_VERSION` 環境変数で注入され、未指定時は `latest-SNAPSHOT`。jar は `-jdk8` classifier 付きにリネームして公開される。
+Pushing a `vX.Y.Z` tag triggers `.github/workflows/publish.yml`, which runs `sonatypeCentralUpload` to publish to Maven Central. The version is injected via `-PpublishVersion` / the `PUBLISH_VERSION` environment variable, defaulting to `latest-SNAPSHOT`. The jar is renamed with a `-jdk8` classifier before publishing.


### PR DESCRIPTION
## Summary

- Add CLAUDE.md to provide guidance for Claude Code (claude.ai/code) when working in this repository
- Documents common commands (build, test, lint), module structure, the protoc plugin's processing flow, and the release process

🤖 Generated with [Claude Code](https://claude.com/claude-code)