### PR TITLE
fix: escape all field names forbidden by protoc's Java generator

### DIFF
--- a/functional-test/src/main/proto/example/keyword.proto
+++ b/functional-test/src/main/proto/example/keyword.proto
@@ -25,3 +25,17 @@ message Keyword {
   string return = 1;
   optional string if = 2;
 }
+
+// protoc escapes fields whose UpperCamelCase name collides with methods of
+// java.lang.Object / MessageLite / MessageOrBuilder by appending "_".
+// ref: kForbiddenNames in protobuf's src/google/protobuf/compiler/java/names.cc
+message ForbiddenName {
+  string serialized_size = 1;
+  optional string cached_size = 2;
+  repeated string unknown_fields = 3;
+  map<string, string> all_fields = 4;
+  string descriptor_for_type = 5;
+  string initialization_error_string = 6;
+  string default_instance_for_type = 7;
+  string parser_for_type = 8;
+}

--- a/functional-test/src/test/kotlin/example/protocol/KeywordTest.kt
+++ b/functional-test/src/test/kotlin/example/protocol/KeywordTest.kt
@@ -38,4 +38,27 @@ class KeywordTest {
         assertThat(result.`if`).isEqualTo("")
         assertThat(result.ifOrNull).isEqualTo(null)
     }
+
+    @Test
+    fun `compileCheck ForbiddenName`() {
+        val result: ForbiddenName = ForbiddenName(
+            serializedSize_ = "hoge",
+            cachedSize_ = null,
+            unknownFields_List = listOf("hoge"),
+            allFields_Map = mapOf("hoge" to "hogeVal"),
+            descriptorForType_ = "hoge",
+            initializationErrorString_ = "hoge",
+            defaultInstanceForType_ = "hoge",
+            parserForType_ = "hoge",
+        )
+        assertThat(result.serializedSize_).isEqualTo("hoge")
+        assertThat(result.cachedSize_).isEqualTo("")
+        assertThat(result.cachedSize_OrNull).isEqualTo(null)
+        assertThat(result.unknownFields_List).isEqualTo(listOf("hoge"))
+        assertThat(result.allFields_Map).isEqualTo(mapOf("hoge" to "hogeVal"))
+        assertThat(result.descriptorForType_).isEqualTo("hoge")
+        assertThat(result.initializationErrorString_).isEqualTo("hoge")
+        assertThat(result.defaultInstanceForType_).isEqualTo("hoge")
+        assertThat(result.parserForType_).isEqualTo("hoge")
+    }
 }

--- a/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/AbstractOrNullGetterGenerator.kt
+++ b/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/AbstractOrNullGetterGenerator.kt
@@ -9,7 +9,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
 import dev.hsbrysk.protoc.gen.util.javaName
 import dev.hsbrysk.protoc.gen.util.javaPackage
-import dev.hsbrysk.protoc.gen.util.pascalCase
+import dev.hsbrysk.protoc.gen.util.javaPascalName
 import dev.hsbrysk.protoc.gen.util.typeName
 
 abstract class AbstractOrNullGetterGenerator : Generator {
@@ -61,11 +61,5 @@ abstract class AbstractOrNullGetterGenerator : Generator {
     }.build()
 
     private val FieldDescriptor.hasMethodName: String
-        get() {
-            return if (name == "class") {
-                "hasClass_"
-            } else {
-                "has${name.pascalCase()}"
-            }
-        }
+        get() = "has$javaPascalName"
 }

--- a/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/FactoryGenerator.kt
+++ b/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/FactoryGenerator.kt
@@ -9,7 +9,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 import dev.hsbrysk.protoc.gen.util.javaName
 import dev.hsbrysk.protoc.gen.util.javaPackage
-import dev.hsbrysk.protoc.gen.util.pascalCase
+import dev.hsbrysk.protoc.gen.util.javaPascalName
 import dev.hsbrysk.protoc.gen.util.typeName
 
 class FactoryGenerator : Generator {
@@ -69,20 +69,10 @@ class FactoryGenerator : Generator {
     }
 
     private val FieldDescriptor.builderMethodName: String
-        get() {
-            return if (name == "class") {
-                when {
-                    isMapField -> "putAllClass_"
-                    isRepeated -> "addAllClass_"
-                    else -> "setClass_"
-                }
-            } else {
-                when {
-                    isMapField -> "putAll${name.pascalCase()}"
-                    isRepeated -> "addAll${name.pascalCase()}"
-                    else -> "set${name.pascalCase()}"
-                }
-            }
+        get() = when {
+            isMapField -> "putAll$javaPascalName"
+            isRepeated -> "addAll$javaPascalName"
+            else -> "set$javaPascalName"
         }
 
     // Create an interface to handle `FileSpec.Builder` and `TypeSpec.Builder` transparently in `applyRecursively`.

--- a/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensions.kt
+++ b/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensions.kt
@@ -100,8 +100,8 @@ private fun enclosingClassNames(
  */
 internal val FieldDescriptor.javaName: String
     get() {
-        val name = if (name == "class") {
-            "class_"
+        val name = if (isForbiddenJavaName) {
+            name.camelCase() + "_"
         } else {
             name.camelCase()
         }
@@ -111,6 +111,41 @@ internal val FieldDescriptor.javaName: String
             else -> name
         }
     }
+
+/**
+ * The PascalCase field name used to build Java accessor method names
+ * (e.g. `set{Name}`, `has{Name}`, `addAll{Name}`).
+ */
+internal val FieldDescriptor.javaPascalName: String
+    get() = if (isForbiddenJavaName) {
+        name.pascalCase() + "_"
+    } else {
+        name.pascalCase()
+    }
+
+// protoc's Java generator appends a trailing "_" to fields whose PascalCase name would
+// collide with methods of the generated message's base classes (java.lang.Object,
+// MessageLite, MessageOrBuilder).
+// Keep in sync with `kForbiddenNames` in protobuf's src/google/protobuf/compiler/java/names.cc
+private val forbiddenJavaNames = setOf(
+    // java.lang.Object:
+    "Class",
+    // com.google.protobuf.MessageLiteOrBuilder:
+    "DefaultInstanceForType",
+    // com.google.protobuf.MessageLite:
+    "ParserForType",
+    "SerializedSize",
+    // com.google.protobuf.MessageOrBuilder:
+    "AllFields",
+    "DescriptorForType",
+    "InitializationErrorString",
+    "UnknownFields",
+    // obsolete. kept for backwards compatibility of generated code
+    "CachedSize",
+)
+
+private val FieldDescriptor.isForbiddenJavaName: Boolean
+    get() = name.pascalCase() in forbiddenJavaNames
 
 /**
  * kotlinpoetのTypeName


### PR DESCRIPTION
## Summary

Follow-up to #14 / #15. The fix in #15 only handled fields named `class`, but protoc's Java generator escapes **any** field whose PascalCase name collides with methods of the generated message's base classes. See `kForbiddenNames` in protobuf's [`src/google/protobuf/compiler/java/names.cc`](https://github.com/protocolbuffers/protobuf/blob/v35.1/src/google/protobuf/compiler/java/names.cc):

- `Class` (java.lang.Object)
- `DefaultInstanceForType` (MessageLiteOrBuilder)
- `ParserForType`, `SerializedSize` (MessageLite)
- `AllFields`, `DescriptorForType`, `InitializationErrorString`, `UnknownFields` (MessageOrBuilder)
- `CachedSize` (obsolete, kept for backward compatibility)

A field like `string serialized_size = 1;` made this plugin emit `setSerializedSize(...)` while the actual Java builder method is `setSerializedSize_(...)`, producing uncompilable code (reproduced for all 8 unhandled names).

## Changes

- `DescriptorExtensions.kt`: define the same forbidden-name set as protoc, judge by the PascalCase name (matching protoc's `IsForbidden`, which also covers spellings like `class_`), and add `javaPascalName` for building accessor method names
- `FactoryGenerator.kt` / `AbstractOrNullGetterGenerator.kt`: drop the `class`-only special casing and use `javaPascalName`
- functional-test: add a `ForbiddenName` message covering singular / optional / repeated / map fields for the forbidden names

## Verification

- `./gradlew check` passes
- `./gradlew :functional-test:clean :functional-test:test -PwithProtocGenKotlin` passes

## Note (out of scope)

protoc has another, separate name adjustment: when accessor names conflict within a message (e.g. `string foo_list = 1;` + `repeated string foo = 2;` both yield `getFooList`), it appends field numbers (`getFooList1`, `addAllFoo2`). This plugin does not handle that yet; it requires porting protoc's conflict-detection logic and is left for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)