### PR TITLE
fix: append field number when accessor names conflict within a message

### DIFF
--- a/functional-test/src/main/proto/example/conflict.proto
+++ b/functional-test/src/main/proto/example/conflict.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package example;
+
+option java_package = "example.protocol";
+option java_multiple_files = true;
+
+// protoc appends the field number to the accessors of both fields when two fields
+// in the same message would generate conflicting accessor names.
+// ref: IsConflicting in protobuf's src/google/protobuf/compiler/java/context.cc
+message ListConflict {
+  string foo_list = 1;
+  repeated string foo = 2;
+}
+
+message CountConflict {
+  optional string bar_count = 1;
+  repeated string bar = 2;
+}
+
+message MapConflict {
+  string baz_count = 1;
+  map<string, string> baz = 2;
+}
+
+enum ConflictColor {
+  CONFLICT_COLOR_UNSPECIFIED = 0;
+  CONFLICT_COLOR_RED = 1;
+}
+
+message EnumValueConflict {
+  ConflictColor color = 1;
+  string color_value = 2;
+}

--- a/functional-test/src/test/kotlin/example/protocol/ConflictTest.kt
+++ b/functional-test/src/test/kotlin/example/protocol/ConflictTest.kt
@@ -1,0 +1,40 @@
+package example.protocol
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+@Suppress("RedundantExplicitType")
+class ConflictTest {
+    @Test
+    fun `compileCheck ListConflict`() {
+        val result: ListConflict = ListConflict(fooList1 = "hoge", foo2List = listOf("bar"))
+        assertThat(result.fooList1).isEqualTo("hoge")
+        assertThat(result.foo2List).isEqualTo(listOf("bar"))
+    }
+
+    @Test
+    fun `compileCheck CountConflict`() {
+        val result: CountConflict = CountConflict(barCount1 = null, bar2List = listOf("bar"))
+        assertThat(result.barCount1).isEqualTo("")
+        assertThat(result.barCount1OrNull).isEqualTo(null)
+        assertThat(result.bar2List).isEqualTo(listOf("bar"))
+    }
+
+    @Test
+    fun `compileCheck MapConflict`() {
+        val result: MapConflict = MapConflict(bazCount1 = "hoge", baz2Map = mapOf("hoge" to "hogeVal"))
+        assertThat(result.bazCount1).isEqualTo("hoge")
+        assertThat(result.baz2Map).isEqualTo(mapOf("hoge" to "hogeVal"))
+    }
+
+    @Test
+    fun `compileCheck EnumValueConflict`() {
+        val result: EnumValueConflict = EnumValueConflict(
+            color1 = ConflictColor.CONFLICT_COLOR_RED,
+            colorValue2 = "hoge",
+        )
+        assertThat(result.color1).isEqualTo(ConflictColor.CONFLICT_COLOR_RED)
+        assertThat(result.colorValue2).isEqualTo("hoge")
+    }
+}

--- a/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensions.kt
+++ b/protoc-gen-kotlin-ext/src/main/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensions.kt
@@ -100,11 +100,7 @@ private fun enclosingClassNames(
  */
 internal val FieldDescriptor.javaName: String
     get() {
-        val name = if (isForbiddenJavaName) {
-            name.camelCase() + "_"
-        } else {
-            name.camelCase()
-        }
+        val name = escapedCamelName + conflictSuffix
         return when {
             isMapField -> name + "Map" // Actually, maps are internally repeated, so they should be checked first.
             isRepeated -> name + "List"
@@ -117,11 +113,70 @@ internal val FieldDescriptor.javaName: String
  * (e.g. `set{Name}`, `has{Name}`, `addAll{Name}`).
  */
 internal val FieldDescriptor.javaPascalName: String
+    get() = escapedPascalName + conflictSuffix
+
+private val FieldDescriptor.escapedCamelName: String
+    get() = if (isForbiddenJavaName) {
+        name.camelCase() + "_"
+    } else {
+        name.camelCase()
+    }
+
+private val FieldDescriptor.escapedPascalName: String
     get() = if (isForbiddenJavaName) {
         name.pascalCase() + "_"
     } else {
         name.pascalCase()
     }
+
+// protoc's Java generator appends the field number to the accessors of both fields when
+// two fields in the same message would generate conflicting accessor names
+// (e.g. `string foo_list = 1;` and `repeated string foo = 2;` both generate `getFooList()`).
+// Keep in sync with `InitializeFieldGeneratorInfoForFields` / `IsConflicting` in
+// protobuf's src/google/protobuf/compiler/java/context.cc
+private val FieldDescriptor.conflictSuffix: String
+    get() {
+        val myName = escapedPascalName
+        val conflicting = containingType.fields.any { other ->
+            other !== this && isConflicting(this, myName, other, other.escapedPascalName)
+        }
+        return if (conflicting) number.toString() else ""
+    }
+
+private fun isConflicting(
+    field1: FieldDescriptor,
+    name1: String,
+    field2: FieldDescriptor,
+    name2: String,
+): Boolean = name1 == name2 ||
+    isConflictingOneWay(field1, name1, field2, name2) ||
+    isConflictingOneWay(field2, name2, field1, name1)
+
+private fun isConflictingOneWay(
+    field1: FieldDescriptor,
+    name1: String,
+    field2: FieldDescriptor,
+    name2: String,
+): Boolean = isRepeatedFieldConflicting(field1, name1, field2, name2) ||
+    isEnumFieldConflicting(field1, name1, name2)
+
+// Both a repeated field `foo` and a singular field `foo_count`/`foo_list` would generate
+// `getFooCount()`/`getFooList()`.
+private fun isRepeatedFieldConflicting(
+    field1: FieldDescriptor,
+    name1: String,
+    field2: FieldDescriptor,
+    name2: String,
+): Boolean = field1.isRepeated && !field2.isRepeated && (name2 == name1 + "Count" || name2 == name1 + "List")
+
+// Both an open enum field `foo` and a regular field `foo_value` would generate `getFooValue()`.
+private fun isEnumFieldConflicting(
+    field1: FieldDescriptor,
+    name1: String,
+    name2: String,
+): Boolean = field1.type == FieldDescriptor.Type.ENUM &&
+    !field1.legacyEnumFieldTreatedAsClosed() &&
+    name2 == name1 + "Value"
 
 // protoc's Java generator appends a trailing "_" to fields whose PascalCase name would
 // collide with methods of the generated message's base classes (java.lang.Object,

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
@@ -180,7 +180,7 @@ class DescriptorExtensionsTest {
 
         // Fields whose capitalized names are identical also conflict.
         // (Only possible in proto2; proto3 rejects it as a JSON name conflict.)
-        val sameName = buildMessage(
+        val sameName = buildProto2Message(
             stringField("foo_bar", 1),
             stringField("fooBar", 2),
         )
@@ -302,8 +302,17 @@ class DescriptorExtensionsTest {
         ).isEqualTo(LIST.parameterizedBy(String::class.asTypeName()))
     }
 
-    private fun buildMessage(vararg fields: FieldDescriptorProto): Descriptor = FileDescriptor.buildFrom(
-        FileDescriptorProto.newBuilder().setName("conflict.proto")
+    private fun buildMessage(vararg fields: FieldDescriptorProto): Descriptor = buildMessage("proto3", *fields)
+
+    // proto2 is only needed for conflict cases that proto3 rejects at the protoc level
+    // (e.g. identical capitalized names).
+    private fun buildProto2Message(vararg fields: FieldDescriptorProto): Descriptor = buildMessage("proto2", *fields)
+
+    private fun buildMessage(
+        syntax: String,
+        vararg fields: FieldDescriptorProto,
+    ): Descriptor = FileDescriptor.buildFrom(
+        FileDescriptorProto.newBuilder().setName("conflict.proto").setSyntax(syntax)
             .addMessageType(DescriptorProto.newBuilder().setName("Conflict").addAllField(fields.toList()))
             .build(),
         arrayOf(),

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.google.protobuf.ByteString
 import com.google.protobuf.DescriptorProtos.DescriptorProto
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto
 import com.google.protobuf.DescriptorProtos.FileOptions
 import com.google.protobuf.Descriptors.Descriptor
@@ -125,11 +126,16 @@ class DescriptorExtensionsTest {
 
     @Test
     fun `FieldDescriptor javaName`() {
+        val noOtherFields: Descriptor = mockk {
+            every { fields } returns emptyList()
+        }
+
         assertThat(
             mockk<FieldDescriptor> {
                 every { isMapField } returns false
                 every { isRepeated } returns false
                 every { name } returns "hoge_bar"
+                every { containingType } returns noOtherFields
             }.javaName,
         ).isEqualTo("hogeBar")
 
@@ -139,6 +145,7 @@ class DescriptorExtensionsTest {
                 every { isMapField } returns false
                 every { isRepeated } returns true
                 every { name } returns "hoge_bar"
+                every { containingType } returns noOtherFields
             }.javaName,
         ).isEqualTo("hogeBarList")
 
@@ -146,9 +153,47 @@ class DescriptorExtensionsTest {
         assertThat(
             mockk<FieldDescriptor> {
                 every { isMapField } returns true
+                every { isRepeated } returns true
                 every { name } returns "hoge_bar"
+                every { containingType } returns noOtherFields
             }.javaName,
         ).isEqualTo("hogeBarMap")
+    }
+
+    @Test
+    fun `FieldDescriptor javaName conflicting accessor names`() {
+        // `string foo_list = 1;` and `repeated string foo = 2;` both generate `getFooList()`,
+        // so protoc appends the field number to both.
+        val listConflict = buildMessage(
+            stringField("foo_list", 1),
+            stringField("foo", 2, repeated = true),
+        )
+        assertThat(listConflict.fields[0].javaName).isEqualTo("fooList1")
+        assertThat(listConflict.fields[1].javaName).isEqualTo("foo2List")
+
+        val countConflict = buildMessage(
+            stringField("bar_count", 1),
+            stringField("bar", 2, repeated = true),
+        )
+        assertThat(countConflict.fields[0].javaName).isEqualTo("barCount1")
+        assertThat(countConflict.fields[1].javaName).isEqualTo("bar2List")
+
+        // Fields whose capitalized names are identical also conflict.
+        // (Only possible in proto2; proto3 rejects it as a JSON name conflict.)
+        val sameName = buildMessage(
+            stringField("foo_bar", 1),
+            stringField("fooBar", 2),
+        )
+        assertThat(sameName.fields[0].javaName).isEqualTo("fooBar1")
+        assertThat(sameName.fields[1].javaName).isEqualTo("fooBar2")
+
+        // Both singular: no conflict, no field number.
+        val noConflict = buildMessage(
+            stringField("baz_list", 1),
+            stringField("baz", 2),
+        )
+        assertThat(noConflict.fields[0].javaName).isEqualTo("bazList")
+        assertThat(noConflict.fields[1].javaName).isEqualTo("baz")
     }
 
     @TestFactory
@@ -256,6 +301,30 @@ class DescriptorExtensionsTest {
             }.typeName,
         ).isEqualTo(LIST.parameterizedBy(String::class.asTypeName()))
     }
+
+    private fun buildMessage(vararg fields: FieldDescriptorProto): Descriptor = FileDescriptor.buildFrom(
+        FileDescriptorProto.newBuilder().setName("conflict.proto")
+            .addMessageType(DescriptorProto.newBuilder().setName("Conflict").addAllField(fields.toList()))
+            .build(),
+        arrayOf(),
+    ).messageTypes.first()
+
+    private fun stringField(
+        name: String,
+        number: Int,
+        repeated: Boolean = false,
+    ): FieldDescriptorProto = FieldDescriptorProto.newBuilder()
+        .setName(name)
+        .setNumber(number)
+        .setType(FieldDescriptorProto.Type.TYPE_STRING)
+        .setLabel(
+            if (repeated) {
+                FieldDescriptorProto.Label.LABEL_REPEATED
+            } else {
+                FieldDescriptorProto.Label.LABEL_OPTIONAL
+            },
+        )
+        .build()
 
     @Test
     fun `FieldDescriptor typeName hasPresence`() {


### PR DESCRIPTION
## Summary

Follow-up to #189. protoc's Java generator has one more name adjustment this plugin didn't handle: when two fields in the same message would generate conflicting accessor names, it appends the **field number** to the accessors of *both* fields. See `IsConflicting` / `InitializeFieldGeneratorInfoForFields` in protobuf's [`src/google/protobuf/compiler/java/context.cc`](https://github.com/protocolbuffers/protobuf/blob/v35.1/src/google/protobuf/compiler/java/context.cc).

The conflict cases (verified against protoc 4.35.1 output):

| Case | Example | Generated Java |
|---|---|---|
| Repeated vs singular `*_list` | `string foo_list = 1;` + `repeated string foo = 2;` | `getFooList1()` / `addAllFoo2(...)` |
| Repeated vs singular `*_count` | `optional string bar_count = 1;` + `repeated string bar = 2;` | `hasBarCount1()` / `addAllBar2(...)` |
| Map counts as repeated | `string baz_count = 1;` + `map<string, string> baz = 2;` | `setBazCount1(...)` / `putAllBaz2(...)` |
| Open enum vs `*_value` | `Color color = 1;` + `string color_value = 2;` | `setColor1(...)` / `setColorValue2(...)` |
| Identical capitalized names | `foo_bar` + `fooBar` (proto2 only; proto3 rejects as JSON name conflict) | `getFooBar1()` / `getFooBar2()` |

For all of these, the plugin previously emitted the unsuffixed names (`setFooList(...)`, `addAllFoo(...)`, ...), producing uncompilable code.

## Changes

- `DescriptorExtensions.kt`: port protoc's conflict detection. Names are compared as forbidden-name-escaped PascalCase (same as protoc, composing with #189), and the field number is appended before the `List`/`Map` suffix. The enum case mirrors `SupportUnknownEnumValue` via `FieldDescriptor.legacyEnumFieldTreatedAsClosed()`.
- Unit tests for the list/count/same-name cases (the proto2-only same-name case is covered here since the functional tests are proto3)
- functional-test: `conflict.proto` + `ConflictTest` covering list/count/map/enum-value conflicts, including the `OrNull` getter with a suffixed `has` method

## Verification

- `./gradlew check` passes
- `./gradlew :functional-test:clean :functional-test:test -PwithProtocGenKotlin` passes
- Generated `ConflictKtExtensions.kt` matches protoc's Java accessor names exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)