### PR TITLE
test: add missing test coverage

### DIFF
--- a/functional-test/src/main/proto/example/legacy.proto
+++ b/functional-test/src/main/proto/example/legacy.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+package example;
+
+option java_package = "example.protocol";
+option java_multiple_files = false;
+
+// protoc-gen-kotlin-ext only targets proto3, so no extension code is generated for this file.
+message LegacyMessage {
+  optional string name = 1;
+}

--- a/functional-test/src/test/kotlin/example/protocol/LegacyTest.kt
+++ b/functional-test/src/test/kotlin/example/protocol/LegacyTest.kt
@@ -1,0 +1,25 @@
+package example.protocol
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import example.protocol.Legacy.LegacyMessage
+import org.junit.jupiter.api.Test
+
+class LegacyTest {
+    @Test
+    fun `proto2 files are compiled but no extension code is generated`() {
+        // protoc's Java generator still processes proto2 files.
+        val message = LegacyMessage.newBuilder().setName("hoge").build()
+        assertThat(message.name).isEqualTo("hoge")
+
+        // Sanity check: for proto3 files, top-level extension functions are compiled
+        // into a `*KtExtensionsKt` class.
+        Class.forName("example.protocol.PersonKtExtensionsKt")
+
+        // protoc-gen-kotlin-ext skips proto2 files, so no extension file is generated.
+        assertFailure { Class.forName("example.protocol.LegacyKtExtensionsKt") }
+            .isInstanceOf(ClassNotFoundException::class)
+    }
+}

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/CompileOptionTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/CompileOptionTest.kt
@@ -52,6 +52,46 @@ class CompileOptionTest {
     }
 
     @Test
+    fun `parseOptions disable individually`() {
+        assertThat(
+            CompileOption.parseOptions(
+                PluginProtos.CodeGeneratorRequest.newBuilder()
+                    .setParameter("orNullGetter-")
+                    .build(),
+            ),
+        ).isEqualTo(setOf(FACTORY))
+
+        // Disabling an option that is off by default is also fine.
+        assertThat(
+            CompileOption.parseOptions(
+                PluginProtos.CodeGeneratorRequest.newBuilder()
+                    .setParameter("messageOrNullGetter-")
+                    .build(),
+            ),
+        ).isEqualTo(setOf(FACTORY, OR_NULL_GETTER))
+    }
+
+    @Test
+    fun `parseOptions duplicated`() {
+        // The last specification wins.
+        assertThat(
+            CompileOption.parseOptions(
+                PluginProtos.CodeGeneratorRequest.newBuilder()
+                    .setParameter("factory-, factory+")
+                    .build(),
+            ),
+        ).isEqualTo(setOf(FACTORY, OR_NULL_GETTER))
+
+        assertThat(
+            CompileOption.parseOptions(
+                PluginProtos.CodeGeneratorRequest.newBuilder()
+                    .setParameter("factory+, factory-")
+                    .build(),
+            ),
+        ).isEqualTo(setOf(OR_NULL_GETTER))
+    }
+
+    @Test
     fun `parseOptions error`() {
         assertFailure {
             CompileOption.parseOptions(

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunnerTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunnerTest.kt
@@ -22,7 +22,9 @@ class GeneratorRunnerTest {
     fun main() {
         val response = runMain(request(""))
 
-        assertThat(response.supportedFeatures).isEqualTo(Feature.FEATURE_PROTO3_OPTIONAL_VALUE.toLong())
+        // supportedFeatures is a bitmask, so check the bit instead of comparing exactly.
+        val proto3Optional = Feature.FEATURE_PROTO3_OPTIONAL_VALUE.toLong()
+        assertThat(response.supportedFeatures and proto3Optional).isEqualTo(proto3Optional)
         // The proto2 file is skipped, so only the proto3 file is generated.
         assertThat(response.fileList.map { it.name }).isEqualTo(listOf("com/example/PersonKtExtensions.kt"))
 

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunnerTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunnerTest.kt
@@ -1,0 +1,112 @@
+package dev.hsbrysk.protoc.gen
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import com.google.protobuf.DescriptorProtos.DescriptorProto
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import com.google.protobuf.DescriptorProtos.FileOptions
+import com.google.protobuf.DescriptorProtos.OneofDescriptorProto
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.Feature
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class GeneratorRunnerTest {
+    @Test
+    fun main() {
+        val response = runMain(request(""))
+
+        assertThat(response.supportedFeatures).isEqualTo(Feature.FEATURE_PROTO3_OPTIONAL_VALUE.toLong())
+        // The proto2 file is skipped, so only the proto3 file is generated.
+        assertThat(response.fileList.map { it.name }).isEqualTo(listOf("com/example/PersonKtExtensions.kt"))
+
+        val content = response.getFile(0).content
+        assertThat(content).contains("public fun Person(firstName: String, nickname: String?): Person")
+        assertThat(content).contains("nicknameOrNull")
+    }
+
+    @Test
+    fun `main compile options are applied`() {
+        val response = runMain(request("factory-"))
+
+        val content = response.getFile(0).content
+        assertThat(content).doesNotContain("public fun Person(")
+        assertThat(content).contains("nicknameOrNull")
+    }
+
+    private fun request(parameter: String): CodeGeneratorRequest = CodeGeneratorRequest.newBuilder()
+        .setParameter(parameter)
+        .addAllFileToGenerate(listOf("person.proto", "legacy.proto"))
+        .addProtoFile(PERSON_PROTO)
+        .addProtoFile(LEGACY_PROTO)
+        .build()
+
+    private fun runMain(request: CodeGeneratorRequest): CodeGeneratorResponse {
+        val originalIn = System.`in`
+        val originalOut = System.out
+        val stdout = ByteArrayOutputStream()
+        try {
+            System.setIn(ByteArrayInputStream(request.toByteArray()))
+            System.setOut(PrintStream(stdout))
+            GeneratorRunner.main(arrayOf())
+        } finally {
+            System.setIn(originalIn)
+            System.setOut(originalOut)
+        }
+        return CodeGeneratorResponse.parseFrom(stdout.toByteArray())
+    }
+
+    companion object {
+        private val PERSON_PROTO: FileDescriptorProto = FileDescriptorProto.newBuilder()
+            .setName("person.proto")
+            .setSyntax("proto3")
+            .setPackage("com.example")
+            .setOptions(FileOptions.newBuilder().setJavaMultipleFiles(true))
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("Person")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("first_name")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL),
+                    )
+                    // `optional` in proto3 is represented as a synthetic oneof.
+                    .addOneofDecl(OneofDescriptorProto.newBuilder().setName("_nickname"))
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("nickname")
+                            .setNumber(2)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                            .setProto3Optional(true)
+                            .setOneofIndex(0),
+                    ),
+            )
+            .build()
+
+        private val LEGACY_PROTO: FileDescriptorProto = FileDescriptorProto.newBuilder()
+            .setName("legacy.proto")
+            .setSyntax("proto2")
+            .setPackage("com.example.legacy")
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("LegacyMessage")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("name")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL),
+                    ),
+            )
+            .build()
+    }
+}

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
@@ -4,9 +4,12 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.google.protobuf.ByteString
 import com.google.protobuf.DescriptorProtos.DescriptorProto
+import com.google.protobuf.DescriptorProtos.EnumDescriptorProto
+import com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto
 import com.google.protobuf.DescriptorProtos.FileOptions
+import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.EnumDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
@@ -98,6 +101,80 @@ class DescriptorExtensionsTest {
         )
 
         assertThat(fileDescriptor.messageTypes.first().javaPackage).isEqualTo("com.example.HogeOuterClass")
+    }
+
+    @Test
+    fun `Descriptor javaPackage outerClass derived from proto filename`() {
+        val fileDescriptor = FileDescriptor.buildFrom(
+            FileDescriptorProto.newBuilder().setName("hoge_bar.proto").setPackage("com.example")
+                .addMessageType(DescriptorProto.newBuilder().setName("Fuga").build())
+                .setOptions(FileOptions.newBuilder().setJavaMultipleFiles(false).build()).build(),
+            arrayOf(),
+        )
+
+        assertThat(fileDescriptor.messageTypes.first().javaPackage).isEqualTo("com.example.HogeBar")
+    }
+
+    @Test
+    fun `Descriptor javaPackage same outerClass as enum`() {
+        val fileDescriptor = FileDescriptor.buildFrom(
+            FileDescriptorProto.newBuilder().setName("hoge.proto").setPackage("com.example")
+                .addEnumType(
+                    EnumDescriptorProto.newBuilder().setName("Hoge")
+                        .addValue(EnumValueDescriptorProto.newBuilder().setName("HOGE_UNSPECIFIED").setNumber(0))
+                        .build(),
+                )
+                .addMessageType(DescriptorProto.newBuilder().setName("Fuga").build())
+                .setOptions(FileOptions.newBuilder().setJavaMultipleFiles(false).build()).build(),
+            arrayOf(),
+        )
+
+        assertThat(fileDescriptor.messageTypes.first().javaPackage).isEqualTo("com.example.HogeOuterClass")
+    }
+
+    @Test
+    fun `Descriptor javaPackage same outerClass as service`() {
+        val fileDescriptor = FileDescriptor.buildFrom(
+            FileDescriptorProto.newBuilder().setName("hoge.proto").setPackage("com.example")
+                .addService(ServiceDescriptorProto.newBuilder().setName("Hoge").build())
+                .addMessageType(DescriptorProto.newBuilder().setName("Fuga").build())
+                .setOptions(FileOptions.newBuilder().setJavaMultipleFiles(false).build()).build(),
+            arrayOf(),
+        )
+
+        assertThat(fileDescriptor.messageTypes.first().javaPackage).isEqualTo("com.example.HogeOuterClass")
+    }
+
+    @Test
+    fun `EnumDescriptor javaPackage`() {
+        val fileDescriptor = FileDescriptor.buildFrom(
+            FileDescriptorProto.newBuilder().setName("sample.proto").setPackage("com.example")
+                .addEnumType(
+                    EnumDescriptorProto.newBuilder().setName("Hoge")
+                        .addValue(EnumValueDescriptorProto.newBuilder().setName("HOGE_UNSPECIFIED").setNumber(0))
+                        .build(),
+                )
+                .setOptions(FileOptions.newBuilder().setJavaMultipleFiles(false).build()).build(),
+            arrayOf(),
+        )
+
+        assertThat(fileDescriptor.enumTypes.first().javaPackage).isEqualTo("com.example.Sample")
+    }
+
+    @Test
+    fun `EnumDescriptor javaPackage multiple files`() {
+        val fileDescriptor = FileDescriptor.buildFrom(
+            FileDescriptorProto.newBuilder().setName("sample.proto").setPackage("com.example")
+                .addEnumType(
+                    EnumDescriptorProto.newBuilder().setName("Hoge")
+                        .addValue(EnumValueDescriptorProto.newBuilder().setName("HOGE_UNSPECIFIED").setNumber(0))
+                        .build(),
+                )
+                .setOptions(FileOptions.newBuilder().setJavaMultipleFiles(true).build()).build(),
+            arrayOf(),
+        )
+
+        assertThat(fileDescriptor.enumTypes.first().javaPackage).isEqualTo("com.example")
     }
 
     @Test
@@ -194,6 +271,54 @@ class DescriptorExtensionsTest {
         )
         assertThat(noConflict.fields[0].javaName).isEqualTo("bazList")
         assertThat(noConflict.fields[1].javaName).isEqualTo("baz")
+    }
+
+    @Test
+    fun `FieldDescriptor javaName enum value conflict`() {
+        // An open enum field `color` and a `color_value` field both generate `getColorValue()`,
+        // so protoc appends the field number to both.
+        val messageDescriptor = FileDescriptor.buildFrom(
+            FileDescriptorProto.newBuilder().setName("conflict.proto").setSyntax("proto3")
+                .addEnumType(
+                    EnumDescriptorProto.newBuilder().setName("Color")
+                        .addValue(EnumValueDescriptorProto.newBuilder().setName("COLOR_UNSPECIFIED").setNumber(0))
+                        .build(),
+                )
+                .addMessageType(
+                    DescriptorProto.newBuilder().setName("Conflict")
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setName("color")
+                                .setNumber(1)
+                                .setType(FieldDescriptorProto.Type.TYPE_ENUM)
+                                .setTypeName(".Color")
+                                .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL),
+                        )
+                        .addField(stringField("color_value", 2)),
+                )
+                .build(),
+            arrayOf(),
+        ).messageTypes.first()
+
+        assertThat(messageDescriptor.fields[0].javaName).isEqualTo("color1")
+        assertThat(messageDescriptor.fields[1].javaName).isEqualTo("colorValue2")
+    }
+
+    @Test
+    fun `FieldDescriptor javaName forbidden names`() {
+        // protoc appends "_" to fields whose PascalCase name collides with methods of
+        // the generated message's base classes.
+        val messageDescriptor = buildMessage(
+            stringField("class", 1),
+            stringField("serialized_size", 2),
+            stringField("unknown_fields", 3, repeated = true),
+        )
+
+        assertThat(messageDescriptor.fields[0].javaName).isEqualTo("class_")
+        assertThat(messageDescriptor.fields[1].javaName).isEqualTo("serializedSize_")
+        assertThat(messageDescriptor.fields[2].javaName).isEqualTo("unknownFields_List")
+        assertThat(messageDescriptor.fields[0].javaPascalName).isEqualTo("Class_")
+        assertThat(messageDescriptor.fields[2].javaPascalName).isEqualTo("UnknownFields_")
     }
 
     @TestFactory


### PR DESCRIPTION
## Summary

Fills gaps in test coverage found by auditing the existing tests against the plugin's behavior. No production code changes.

### GeneratorRunnerTest (new)

The plugin entry point had no test at all. This adds an integration test that swaps stdin/stdout and drives `GeneratorRunner.main` with a `CodeGeneratorRequest`:

- generated file path (`com/example/PersonKtExtensions.kt`) and content (factory function, `*OrNull` property)
- **proto2 files are skipped** (this filter had no coverage anywhere)
- `supportedFeatures` includes `FEATURE_PROTO3_OPTIONAL`
- compile options (`factory-`) are reflected in the output

### DescriptorExtensionsTest

- enum field `color` vs `color_value` accessor conflict (`isEnumFieldConflicting` was only covered in functional-test)
- forbidden Java name escaping (`class` → `class_`, `serialized_size` → `serializedSize_`, repeated combination `unknownFields_List`) and `javaPascalName`
- `EnumDescriptor.javaPackage` (only the message `Descriptor` variant was tested)
- outer class name derived from the proto filename (existing tests only used `java_outer_classname`)
- outer class name conflicting with an **enum / service** (unit tests only covered the message case)

### CompileOptionTest

- last-wins behavior for duplicated options (`factory-, factory+` / `factory+, factory-`)
- disabling options individually, including a default-off option

### functional-test: legacy.proto + LegacyTest (new)

End-to-end check that a proto2 file mixed into the build doesn't break the plugin: protoc's Java generator still compiles it, while no `LegacyKtExtensionsKt` is generated. A sanity check on `PersonKtExtensionsKt` guards the class-name assumption.

## Testing

- `./gradlew check`
- `./gradlew :functional-test:clean :functional-test:test -PwithProtocGenKotlin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)