### PR TITLE
test: improve boundary-case test coverage

### DIFF
--- a/functional-test/src/main/proto/example/all_type.proto
+++ b/functional-test/src/main/proto/example/all_type.proto
@@ -27,8 +27,8 @@ message AllTypeMessage {
   optional uint64 op_uint64_fd = 17;
   repeated uint64 rp_uint64_fd = 18;
   sint32 sint32_fd = 19;
-  optional sint64 op_sint32_fd = 20;
-  repeated sint64 rp_sint32_fd = 21;
+  optional sint32 op_sint32_fd = 20;
+  repeated sint32 rp_sint32_fd = 21;
   sint64 sint64_fd = 22;
   optional sint64 op_sint64_fd = 46;
   repeated sint64 rp_sint64_fd = 23;

--- a/functional-test/src/main/proto/example/conflict.proto
+++ b/functional-test/src/main/proto/example/conflict.proto
@@ -23,6 +23,13 @@ message MapConflict {
   map<string, string> baz = 2;
 }
 
+// Both repeated: the accessors are getFooListList() and getFooList(), which do not
+// conflict, so protoc does not append the field numbers.
+message NoListConflict {
+  repeated string foo_list = 1;
+  repeated string foo = 2;
+}
+
 enum ConflictColor {
   CONFLICT_COLOR_UNSPECIFIED = 0;
   CONFLICT_COLOR_RED = 1;

--- a/functional-test/src/main/proto/example/presence.proto
+++ b/functional-test/src/main/proto/example/presence.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package example;
+
+option java_package = "example.protocol";
+option java_multiple_files = true;
+
+// Verifies protobuf's presence semantics through the generated factory functions and
+// `xxxOrNull` getters: an unset field is null, while a field explicitly set to its
+// type's default value still has presence.
+message PresenceMessage {
+  optional int32 op_int32_fd = 1;
+  optional bool op_bool_fd = 2;
+  optional string op_string_fd = 3;
+  optional PresenceEnum op_enum_fd = 4;
+  oneof test_one_of {
+    string one_of_string_fd = 5;
+  }
+  PresenceChild message_fd = 6;
+}
+
+message PresenceChild {
+  int32 value = 1;
+}
+
+enum PresenceEnum {
+  PRESENCE_ENUM_UNSPECIFIED = 0;
+  PRESENCE_ENUM_A = 1;
+}

--- a/functional-test/src/test/kotlin/example/protocol/AllTypeMessageTest.kt
+++ b/functional-test/src/test/kotlin/example/protocol/AllTypeMessageTest.kt
@@ -10,6 +10,9 @@ class AllTypeMessageTest {
     @Test
     @Suppress("LongMethod")
     fun compileCheck() {
+        // Compile-level check that sint32 fields map to Int (not Long).
+        val sint32Value: Int = 0
+        val opSint32Value: Int? = null
         val obj: AllTypeMessage = AllTypeMessage(
             doubleFd = 0.0,
             opDoubleFd = null,
@@ -29,9 +32,9 @@ class AllTypeMessageTest {
             uint64Fd = 0,
             opUint64Fd = null,
             rpUint64FdList = listOf(),
-            sint32Fd = 0,
-            opSint32Fd = null,
-            rpSint32FdList = listOf(),
+            sint32Fd = sint32Value,
+            opSint32Fd = opSint32Value,
+            rpSint32FdList = listOf(sint32Value),
             sint64Fd = 0,
             opSint64Fd = null,
             rpSint64FdList = listOf(),
@@ -72,7 +75,8 @@ class AllTypeMessageTest {
         assertThat(obj.opInt64FdOrNull).isNull()
         assertThat(obj.opUint32FdOrNull).isNull()
         assertThat(obj.opUint64FdOrNull).isNull()
-        assertThat(obj.opSint32FdOrNull).isNull()
+        val opSint32FdOrNull: Int? = obj.opSint32FdOrNull
+        assertThat(opSint32FdOrNull).isNull()
         assertThat(obj.opSint64FdOrNull).isNull()
         assertThat(obj.opFixed32FdOrNull).isNull()
         assertThat(obj.opFixed64FdOrNull).isNull()

--- a/functional-test/src/test/kotlin/example/protocol/ConflictTest.kt
+++ b/functional-test/src/test/kotlin/example/protocol/ConflictTest.kt
@@ -29,6 +29,14 @@ class ConflictTest {
     }
 
     @Test
+    fun `compileCheck NoListConflict`() {
+        // Both repeated, so the accessors don't conflict and no field number is appended.
+        val result: NoListConflict = NoListConflict(fooListList = listOf("hoge"), fooList = listOf("bar"))
+        assertThat(result.fooListList).isEqualTo(listOf("hoge"))
+        assertThat(result.fooList).isEqualTo(listOf("bar"))
+    }
+
+    @Test
     fun `compileCheck EnumValueConflict`() {
         val result: EnumValueConflict = EnumValueConflict(
             color1 = ConflictColor.CONFLICT_COLOR_RED,

--- a/functional-test/src/test/kotlin/example/protocol/PresenceTest.kt
+++ b/functional-test/src/test/kotlin/example/protocol/PresenceTest.kt
@@ -1,0 +1,62 @@
+package example.protocol
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+
+class PresenceTest {
+    @Test
+    fun `null factory arguments do not set the fields`() {
+        val obj = PresenceMessage(
+            opInt32Fd = null,
+            opBoolFd = null,
+            opStringFd = null,
+            opEnumFd = null,
+            oneOfStringFd = null,
+            messageFd = null,
+        )
+
+        assertThat(obj.hasOpInt32Fd()).isFalse()
+        assertThat(obj.opInt32FdOrNull).isNull()
+        assertThat(obj.hasOpBoolFd()).isFalse()
+        assertThat(obj.opBoolFdOrNull).isNull()
+        assertThat(obj.hasOpStringFd()).isFalse()
+        assertThat(obj.opStringFdOrNull).isNull()
+        assertThat(obj.hasOpEnumFd()).isFalse()
+        assertThat(obj.opEnumFdOrNull).isNull()
+        assertThat(obj.hasOneOfStringFd()).isFalse()
+        assertThat(obj.oneOfStringFdOrNull).isNull()
+        assertThat(obj.testOneOfCase).isEqualTo(PresenceMessage.TestOneOfCase.TESTONEOF_NOT_SET)
+        assertThat(obj.hasMessageFd()).isFalse()
+        assertThat(obj.messageFdOrNull).isNull()
+    }
+
+    @Test
+    fun `fields explicitly set to their default values still have presence`() {
+        val obj = PresenceMessage(
+            opInt32Fd = 0,
+            opBoolFd = false,
+            opStringFd = "",
+            opEnumFd = PresenceEnum.PRESENCE_ENUM_UNSPECIFIED,
+            oneOfStringFd = "",
+            messageFd = PresenceChild(value = 0),
+        )
+
+        assertThat(obj.hasOpInt32Fd()).isTrue()
+        assertThat(obj.opInt32FdOrNull).isEqualTo(0)
+        assertThat(obj.hasOpBoolFd()).isTrue()
+        assertThat(obj.opBoolFdOrNull).isEqualTo(false)
+        assertThat(obj.hasOpStringFd()).isTrue()
+        assertThat(obj.opStringFdOrNull).isEqualTo("")
+        assertThat(obj.hasOpEnumFd()).isTrue()
+        assertThat(obj.opEnumFdOrNull).isEqualTo(PresenceEnum.PRESENCE_ENUM_UNSPECIFIED)
+        assertThat(obj.hasOneOfStringFd()).isTrue()
+        assertThat(obj.oneOfStringFdOrNull).isEqualTo("")
+        assertThat(obj.testOneOfCase).isEqualTo(PresenceMessage.TestOneOfCase.ONE_OF_STRING_FD)
+        assertThat(obj.hasMessageFd()).isTrue()
+        assertThat(obj.messageFdOrNull).isEqualTo(PresenceChild(value = 0))
+    }
+}

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunnerTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/GeneratorRunnerTest.kt
@@ -29,16 +29,36 @@ class GeneratorRunnerTest {
         assertThat(response.fileList.map { it.name }).isEqualTo(listOf("com/example/PersonKtExtensions.kt"))
 
         val content = response.getFile(0).content
-        assertThat(content).contains("public fun Person(firstName: String, nickname: String?): Person")
+        assertThat(content).contains(PERSON_FACTORY_SIGNATURE)
         assertThat(content).contains("nicknameOrNull")
+        // messageOrNullGetter is off by default.
+        assertThat(content).doesNotContain("addressOrNull")
     }
 
     @Test
-    fun `main compile options are applied`() {
+    fun `main factory disabled`() {
         val response = runMain(request("factory-"))
 
         val content = response.getFile(0).content
         assertThat(content).doesNotContain("public fun Person(")
+        assertThat(content).contains("nicknameOrNull")
+    }
+
+    @Test
+    fun `main orNullGetter disabled`() {
+        val response = runMain(request("orNullGetter-"))
+
+        val content = response.getFile(0).content
+        assertThat(content).contains(PERSON_FACTORY_SIGNATURE)
+        assertThat(content).doesNotContain("nicknameOrNull")
+    }
+
+    @Test
+    fun `main messageOrNullGetter enabled`() {
+        val response = runMain(request("messageOrNullGetter+"))
+
+        val content = response.getFile(0).content
+        assertThat(content).contains("public val PersonOrBuilder.addressOrNull: Address?")
         assertThat(content).contains("nicknameOrNull")
     }
 
@@ -65,6 +85,15 @@ class GeneratorRunnerTest {
     }
 
     companion object {
+        private val PERSON_FACTORY_SIGNATURE =
+            """
+            |public fun Person(
+            |  firstName: String,
+            |  nickname: String?,
+            |  address: Address?,
+            |): Person
+            """.trimMargin()
+
         private val PERSON_PROTO: FileDescriptorProto = FileDescriptorProto.newBuilder()
             .setName("person.proto")
             .setSyntax("proto3")
@@ -90,6 +119,26 @@ class GeneratorRunnerTest {
                             .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
                             .setProto3Optional(true)
                             .setOneofIndex(0),
+                    )
+                    // A message field in proto3 always has presence.
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("address")
+                            .setNumber(3)
+                            .setType(FieldDescriptorProto.Type.TYPE_MESSAGE)
+                            .setTypeName(".com.example.Address")
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL),
+                    ),
+            )
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("Address")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("city")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL),
                     ),
             )
             .build()

--- a/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
+++ b/protoc-gen-kotlin-ext/src/test/kotlin/dev/hsbrysk/protoc/gen/util/DescriptorExtensionsTest.kt
@@ -271,38 +271,61 @@ class DescriptorExtensionsTest {
         )
         assertThat(noConflict.fields[0].javaName).isEqualTo("bazList")
         assertThat(noConflict.fields[1].javaName).isEqualTo("baz")
+
+        // Both repeated: repeated `foo_list` generates `getFooListList()` while repeated `foo`
+        // generates `getFooList()`, so the actual accessors don't conflict and no field number
+        // is appended.
+        val bothRepeated = buildMessage(
+            stringField("foo_list", 1, repeated = true),
+            stringField("foo", 2, repeated = true),
+        )
+        assertThat(bothRepeated.fields[0].javaName).isEqualTo("fooListList")
+        assertThat(bothRepeated.fields[1].javaName).isEqualTo("fooList")
     }
 
     @Test
     fun `FieldDescriptor javaName enum value conflict`() {
         // An open enum field `color` and a `color_value` field both generate `getColorValue()`,
         // so protoc appends the field number to both.
-        val messageDescriptor = FileDescriptor.buildFrom(
-            FileDescriptorProto.newBuilder().setName("conflict.proto").setSyntax("proto3")
-                .addEnumType(
-                    EnumDescriptorProto.newBuilder().setName("Color")
-                        .addValue(EnumValueDescriptorProto.newBuilder().setName("COLOR_UNSPECIFIED").setNumber(0))
-                        .build(),
-                )
-                .addMessageType(
-                    DescriptorProto.newBuilder().setName("Conflict")
-                        .addField(
-                            FieldDescriptorProto.newBuilder()
-                                .setName("color")
-                                .setNumber(1)
-                                .setType(FieldDescriptorProto.Type.TYPE_ENUM)
-                                .setTypeName(".Color")
-                                .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL),
-                        )
-                        .addField(stringField("color_value", 2)),
-                )
-                .build(),
-            arrayOf(),
-        ).messageTypes.first()
+        val messageDescriptor = buildEnumValueMessage("proto3")
 
         assertThat(messageDescriptor.fields[0].javaName).isEqualTo("color1")
         assertThat(messageDescriptor.fields[1].javaName).isEqualTo("colorValue2")
     }
+
+    @Test
+    fun `FieldDescriptor javaName closed enum value no conflict`() {
+        // proto2 enums are closed, so protoc doesn't generate `getColorValue()` for the enum
+        // field and `color` / `color_value` keep their names without field numbers.
+        val messageDescriptor = buildEnumValueMessage("proto2")
+
+        assertThat(messageDescriptor.fields[0].javaName).isEqualTo("color")
+        assertThat(messageDescriptor.fields[1].javaName).isEqualTo("colorValue")
+    }
+
+    // A message with an enum field `color` and a string field `color_value`.
+    private fun buildEnumValueMessage(syntax: String): Descriptor = FileDescriptor.buildFrom(
+        FileDescriptorProto.newBuilder().setName("conflict.proto").setSyntax(syntax)
+            .addEnumType(
+                EnumDescriptorProto.newBuilder().setName("Color")
+                    .addValue(EnumValueDescriptorProto.newBuilder().setName("COLOR_UNSPECIFIED").setNumber(0))
+                    .build(),
+            )
+            .addMessageType(
+                DescriptorProto.newBuilder().setName("Conflict")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("color")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_ENUM)
+                            .setTypeName(".Color")
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL),
+                    )
+                    .addField(stringField("color_value", 2)),
+            )
+            .build(),
+        arrayOf(),
+    ).messageTypes.first()
 
     @Test
     fun `FieldDescriptor javaName forbidden names`() {


### PR DESCRIPTION
## Summary

- Fix sint32 fields mistakenly declared as `sint64` in `all_type.proto` (`op_sint32_fd` / `rp_sint32_fd`) and verify at compile level that the generated factory parameters and `*OrNull` getter map to `Int`, using explicitly-typed values (integer literals would silently adapt to `Long`)
- Add `presence.proto` / `PresenceTest` verifying protobuf presence semantics through the generated factory functions and `*OrNull` getters:
  - all-null factory arguments leave fields unset (`hasXxx() == false`, `xxxOrNull == null`, oneof case `NOT_SET`)
  - fields explicitly set to their type's default value (int32=0, bool=false, string="", enum 0, empty oneof string, default message instance) still have presence (`hasXxx() == true`, `xxxOrNull` returns the default)
- Add `GeneratorRunnerTest` cases for compile options, verifying the final `CodeGeneratorResponse` content: `orNullGetter-` keeps the factory but drops scalar `*OrNull` getters, and `messageOrNullGetter+` emits `*OrNull` for message-type fields (test proto extended with a message-type `address` field)
- Add the non-conflicting side of the accessor-name conflict detection: proto2 closed enums (`color` / `color_value`) and repeated `foo` / `foo_list` pairs keep their names without field numbers — the latter also verified against protoc's actual Java output via a functional test (`NoListConflict`)

## Test plan

- [x] `./gradlew check`
- [x] `./gradlew :functional-test:clean :functional-test:test -PwithProtocGenKotlin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)